### PR TITLE
add support for setting the compression type passed to dpkg-deb

### DIFF
--- a/src/main/java/net/sf/debianmaven/PackageMojo.java
+++ b/src/main/java/net/sf/debianmaven/PackageMojo.java
@@ -221,6 +221,12 @@ public class PackageMojo extends AbstractDebianMojo
 	protected Set<String> excludedScopes;
 
 	/**
+	 * @parameter default-value="xz"
+	 * @since 1.0.21
+	 */
+	protected String compressionType;
+
+	/**
 	 * The Maven project object
 	 * 
 	 * @parameter expression="${project}"
@@ -470,6 +476,10 @@ public class PackageMojo extends AbstractDebianMojo
 			}
 		}
 		return excludedScopes;
+	}
+
+	private String getCompressionType() {
+		return compressionType == null? "xz" : compressionType;
 	}
 
 	private boolean includeArtifact(Artifact a)
@@ -865,7 +875,7 @@ public class PackageMojo extends AbstractDebianMojo
 
 	private void generatePackage() throws IOException, MojoExecutionException
 	{
-		runProcess(new String[]{"fakeroot", "--", "dpkg-deb", "--build", stageDir.toString(), getPackageFile().toString()}, true);
+		runProcess(new String[]{"fakeroot", "--", "dpkg-deb", "-Z", getCompressionType(), "--build", stageDir.toString(), getPackageFile().toString()}, true);
 	}
 
 	private void checkDeprecated(boolean haveParameter, String paramName) throws MojoExecutionException

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -102,6 +102,8 @@ Usage
 *------------------+-----------------------+------------------------+-----------+------------------------+
   fileFiltering    |                       | If enabled, allows replacing of variables ("$\{...\}") in files that match the <<<include>>> (default: .*) but not the <<<exclude>>> (default: .*\\.(jpg\|jpeg\|png\|svg\|zip\|jar\|pdf)) pattern. | FileFiltering | disabled
 *------------------+-----------------------+------------------------+-----------+------------------------+
+  compressionType  |                       | The type of compression to use (gz, xz, etc.) | String | xz
+*------------------+-----------------------+------------------------+-----------+------------------------+
   repository       | deb.repository.location | Location of the Debian repository | File |
 *------------------+-----------------------+------------------------+-----------+------------------------+
   codenames        |                       | The codenames of the distribution branches (e.g., lenny, natty, etc.) | String | experimental


### PR DESCRIPTION
our CI system was updated to use ubuntu 22 and now it's building packages with `zstd` compression by default; this PR lets you specify the compression type (and defaults to `xz`) to be more backwards-compatible